### PR TITLE
Support modification times as modification differentiators

### DIFF
--- a/server.py
+++ b/server.py
@@ -617,7 +617,7 @@ while True:
                 # If we have an ETag and it matches our file, return 304 Not Modified
                 if Etag == ETag(file):
                     # ETag matches. Return our basic headers, plus the ETag
-                    read.conn.sendall(basicHeaders("304 Not Modified", type)+b"ETag: \""+Etag+b"\"\r\n\r\n")
+                    read.conn.sendall(basicHeaders("304 Not Modified", type)+b"ETag: \""+Etag+b"\"\r\nLast-Modified: "+HTTP_time(os.path.getmtime(filename)).encode()+b"\r\n\r\n")
                     logger.info("Client already has this file (matching hash %s) - Issued 304.", Etag.decode())
 
                     # Close the connection and move on.

--- a/server.py
+++ b/server.py
@@ -255,7 +255,7 @@ def ETag(content):
         return base64.urlsafe_b64encode(hashlib.sha256(content).digest())
 
 def HTTP_time(at=time.time()):
-    "Returns a string formatted as an HTTP time, corresponding to the time specified by at (defaults to the present)"
+    "Returns a string formatted as an HTTP time, corresponding to the unix time specified by at (defaults to the present)"
 
     return time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(at))
 
@@ -627,10 +627,10 @@ while True:
 
             # If the method is GET, use sendResponse to send the file contents.
             if method.startswith(b"GET"):
-                sendResponse("200 OK", type, file, read.conn)
+                sendResponse("200 OK", type, file, read.conn, ["Last-Modified: "+HTTP_time(os.path.getmtime(filename))])
             # If the method is HEAD, generate the same response, but strip the body
             else:
-                read.conn.sendall(constructResponse(basicHeaders("200 OK", type), file).split("\r\n\r\n")[0]+"\r\n\r\n")
+                read.conn.sendall(constructResponse(basicHeaders("200 OK", type)+b"Last-Modified: "+HTTP_time(os.path.getmtime(filename)).encode()+b"\r\n", file).split("\r\n\r\n")[0]+"\r\n\r\n")
                 logger.info("Sent headers to socket %d.", read.fileno())
 
             # Now that we're done, close the connection and move on.

--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ import socket
 import select
 import sys
 import time
+import calendar
 import os
 import hashlib
 import base64
@@ -258,6 +259,11 @@ def HTTP_time(at=time.time()):
     "Returns a string formatted as an HTTP time, corresponding to the unix time specified by at (defaults to the present)"
 
     return time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(at))
+
+def parse_HTTP_time(at):
+    "Returns a Unix timestamp from an HTTP timestamp"
+
+    return calendar.timegm(time.strptime(at, "%a, %d %b %Y %H:%M:%S GMT"))
 
 def basicHeaders(status, contentType):
     "Constructs and returns a basic set of headers for a response (Does not end the header block)"

--- a/server.py
+++ b/server.py
@@ -254,11 +254,16 @@ def ETag(content):
     else:
         return base64.urlsafe_b64encode(hashlib.sha256(content).digest())
 
+def HTTP_time(at=time.time()):
+    "Returns a string formatted as an HTTP time, corresponding to the time specified by at (defaults to the present)"
+
+    return time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(at))
+
 def basicHeaders(status, contentType):
     "Constructs and returns a basic set of headers for a response (Does not end the header block)"
 
     out =  "HTTP/1.1 "+status+"\r\n"
-    out += "Date: "+time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime())+"\r\n"
+    out += "Date: "+HTTP_time()+"\r\n"
     out += "Server: Cadence purpose-built webserver\r\n"
     out += "Connection: close\r\n"
 

--- a/server.py
+++ b/server.py
@@ -630,7 +630,7 @@ while True:
                             mtime = parse_HTTP_time(mt)
                             logger.debug("Found header - mtime %f, from timestamp %s.", mtime, mt.decode())
 
-                    if mtime>=os.path.getmtime(filename):
+                    if mtime>=math.floor(os.path.getmtime(filename)):
                         # Last modified time was given (all NaN comparisons return false), and the file has not since been modified.
                         # Return basic headers, plus ETag and mtime
                         read.conn.sendall(basicHeaders("304 Not Modified", type)+b"ETag: \""+ETag(file)+b"\"\r\nLast-Modified: "+HTTP_time(os.path.getmtime(filename)).encode()+b"\r\n\r\n")


### PR DESCRIPTION
Merging this pull request allows the server to use modification time (`mtime`) to tell a browser that the file it's requesting has not been modified.

This might slightly increase the compatibility of the server's caching information directives with browsers of a certain age.

@kenellorando - This means that the server now supports both the file contents (with the `ETag` being a SHA256 hash of the contents of the file being served to the client), and the time of the last modification of that file (as reported by the filesystem) as ways to tell the browser whether the file it's asking for has been modified (as compared to a copy it has in cache).