### PR TITLE
Use configuration files to configure logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # Don't version control logs
 logs/
+
+# Don't version control the override config file
+config.ini

--- a/default-config.ini
+++ b/default-config.ini
@@ -1,8 +1,9 @@
 # Default configuration options
 # Overriden by options set in config.ini (untracked by git, does not need to exist)
 
+[DEFAULT]
 # Logging configuration
-[logging]
+
 # Levels as set by Python
 # The value may either be one of these integers, or one of these strings:
 #   CRITICAL = 50

--- a/default-config.ini
+++ b/default-config.ini
@@ -1,5 +1,6 @@
 # Default configuration options
 # Overriden by options set in config.ini (untracked by git, does not need to exist)
+# These options should be set in the same [DEFAULT] section.
 
 [DEFAULT]
 # Logging configuration

--- a/default-config.ini
+++ b/default-config.ini
@@ -1,0 +1,51 @@
+# Default configuration options
+# Overriden by options set in config.ini (untracked by git, does not need to exist)
+
+# Logging configuration
+[logging]
+# Levels as set by Python
+# The value may either be one of these integers, or one of these strings:
+#   CRITICAL = 50
+#   ERROR    = 40
+#   WARNING  = 30
+#   INFO     = 20
+#   DEBUG    = 10
+#
+# Log entries at or above the set level are emitted (both to disk and to the console, if enabled)
+# Log entries below the set level are ignored
+level = INFO
+
+# Logging format
+# See https://docs.python.org/3/library/logging.html#logging.Formatter for documentation
+# The default format appears like:
+# [2018-07-28 21:29:24,180] INFO Accepting a new connection.
+format = [%(asctime)s] %(levelname)s %(message)s
+
+# These two options control logging to either the console or the disk
+# At least one must be enabled to emit logs.
+# If both are disabled, then the used logger will be configured so that no log entry can be emitted,
+#   and logs will be configured to be sent to stdout.
+to_console = on
+to_disk = on
+
+# If to_console is enabled, this option sets the stream to which logging is written.
+# Can either be 'stdout' or 'stderr'
+stream = stderr
+
+
+# If to_disk is enabled, these options set the location to which logs are written
+# Logs are written to a rotating file: The configured file is current.
+# Once daily, the log file has the date appended to it (as an extension), and the configured file is emptied
+# Old logs are kept for 30 days.
+
+# Directory is relative to the directory in which server.py is kept.
+# A word of caution: The default directory is ignored by git. Other directories may not be.
+# Be careful to avoid tracking logs in git.
+directory = logs
+
+# File is the name of the current log within the configured directory.
+file = server
+
+# This parameter provides the name of the logger used by the server.
+# I've never noticed any change caused by changing it, but perhaps if you want to include it in the format string or something, this could come in handy.
+logger = Cadence Server

--- a/default-config.ini
+++ b/default-config.ini
@@ -15,27 +15,27 @@
 #
 # Log entries at or above the set level are emitted (both to disk and to the console, if enabled)
 # Log entries below the set level are ignored
-level = INFO
+loglevel = INFO
 
 # Logging format
 # See https://docs.python.org/3/library/logging.html#logging.Formatter for documentation
 # The default format appears like:
 # [2018-07-28 21:29:24,180] INFO Accepting a new connection.
-format = [%(asctime)s] %(levelname)s %(message)s
+logformat = [%(asctime)s] %(levelname)s %(message)s
 
 # These two options control logging to either the console or the disk
 # At least one must be enabled to emit logs.
 # If both are disabled, then the used logger will be configured so that no log entry can be emitted,
 #   and logs will be configured to be sent to stdout.
-to_console = on
-to_disk = on
+log_to_console = on
+log_to_disk = on
 
-# If to_console is enabled, this option sets the stream to which logging is written.
+# If log_to_console is enabled, this option sets the stream to which logging is written.
 # Can either be 'stdout' or 'stderr'
-stream = stderr
+logstream = stderr
 
 
-# If to_disk is enabled, these options set the location to which logs are written
+# If log_to_disk is enabled, these options set the location to which logs are written
 # Logs are written to a rotating file: The configured file is current.
 # Once daily, the log file has the date appended to it (as an extension), and the configured file is emptied
 # Old logs are kept for 30 days.
@@ -43,10 +43,10 @@ stream = stderr
 # Directory is relative to the directory in which server.py is kept.
 # A word of caution: The default directory is ignored by git. Other directories may not be.
 # Be careful to avoid tracking logs in git.
-directory = logs
+logdirectory = logs
 
 # File is the name of the current log within the configured directory.
-file = server
+logfile = server
 
 # This parameter provides the name of the logger used by the server.
 # I've never noticed any change caused by changing it, but perhaps if you want to include it in the format string or something, this could come in handy.

--- a/server.py
+++ b/server.py
@@ -15,8 +15,19 @@ import logging.handlers
 from telnetlib import Telnet
 from urllib import parse
 from threading import Thread
+from configparser import ConfigParser
 
 # Prep work
+# Load in our configuration
+# First, load in the defaults
+defaultconfig = ConfigParser(interpolation=None)
+defaultconfig.read('default-config.ini')
+
+# Now use those defaults to load in the overrides
+config = ConfigParser(defaults=defaultconfig['DEFAULT'], interpolation=None)
+config.read('config.ini')
+config = config['DEFAULT']
+
 # If logs directory does not exist, create it
 logdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
 if not os.path.exists(logdir):

--- a/server.py
+++ b/server.py
@@ -28,18 +28,63 @@ config = ConfigParser(defaults=defaultconfig['DEFAULT'], interpolation=None)
 config.read('config.ini')
 config = config['DEFAULT']
 
+level = config['loglevel']
+# Translate a log level (as configured) into a useful log level
+leveldict = {
+    "DEBUG"    : logging.DEBUG,
+    "INFO"     : logging.INFO,
+    "WARNING"  : logging.WARNING,
+    "ERROR"    : logging.ERROR,
+    "CRITICAL" : logging.CRITICAL
+}
+
+# Check if our log level is a valid name
+if level in leveldict.keys():
+    level = leveldict[level]
+# If it isn't, try to convert it from an integer
+else:
+    try:
+        level = int(level)
+    except ValueError as ex:
+        # We don't understand this level.
+        # Raise a new exception with a somewhat more helpful error
+        raise RuntimeError("Could not interpret \""+level+"\" as a valid logging level") from ex
+
 # If logs directory does not exist, create it
-logdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+logdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), config['logdirectory'])
+logdir = os.path.realpath(logdir)
 if not os.path.exists(logdir):
     os.makedirs(logdir)
 
+# Prepare the handlers for our logger (using the data as configured)
+handlers = []
+if config.getboolean('log_to_console'):
+    # Find the correct stream and add it
+    if config['logstream']=="stdout":
+        handlers.append(logging.StreamHandler(sys.stdout))
+    elif config['logstream']=="stderr":
+        handlers.append(logging.StreamHandler(sys.stderr))
+    else:
+        # No found handler. Warn the user and use stderr
+        from warnings import warn
+        warn("Could not parse "+config['logstream']+" as a console stream. Using stderr.")
+        handlers.append(logging.StreamHandler(sys.stderr))
+if config.getboolean('log_to_disk'):
+    # Assemble and add the timed rotating file handler
+    handlers.append(logging.handlers.TimedRotatingFileHandler(os.path.join(logdir, config['logfile']), 'D', 1, 30))
+
+# If the handlers list is empty, reconfigure so that logging uses a StreamHandler, but has an unreasonably high logging level.
+# That way, logging will be effectively disabled, without adding any code anywhere else
+if len(handlers)==0:
+    handlers.append(logging.StreamHandler(sys.stdout))
+    level=math.pow(2, 64)
+
 # Log both to the console and to a daily rotating file, storing no more than 30 days of logs
-logging.basicConfig(level=logging.INFO,
-                    format="[%(asctime)s] %(levelname)s %(message)s",
-                    handlers=[
-                        logging.StreamHandler(),
-                        logging.handlers.TimedRotatingFileHandler(os.path.join(logdir, "server"), 'D', 1, 30)])
-logger = logging.getLogger("Cadence Server")
+logging.basicConfig(level=level,
+                    format=config['logformat'],
+                    handlers=handlers)
+logger = logging.getLogger(config['logger'])
+logger.setLevel(level)
 
 port = int(sys.argv[1])
 directory = os.path.realpath(sys.argv[2]).encode()


### PR DESCRIPTION
The logging is now configured by the pair of configuration files `default-config.ini` and `config.ini`. The former is tracked in git, but the latter is not.

The former includes plenty of comments on how the configuration is set up, and what various options do, and a default value for each option.

The latter file, which doesn't need to exist for the server to run, contains options which are used to override those present in `default-config.ini`. Anyone running an instance of the server on their own can use `config.ini` to configure the server to suit them - Any options which are not present in that file will simply default to the setting from the defaults file.

This PR fixes #21 .