### PR TITLE
Remove block until sockets are ready for writes

### DIFF
--- a/server.py
+++ b/server.py
@@ -1239,3 +1239,9 @@ while True:
             # Now that we're done, close the connection and move on.
             read.conn.close()
             openconn.remove(read.conn)
+
+    # Now, handle the writeable sockets
+    logger.debug("Selected %d writeable sockets.", len(writeable))
+    for write in writeable:
+        # Handling writes is a lot easier than reads, because the read logic has made all the decisions.
+        write.conn.sendall(write.content)

--- a/server.py
+++ b/server.py
@@ -381,6 +381,11 @@ def constructResponse(unendedHeaders, content, etag=None):
         response += content
     return response
 
+def queueResponse(response, sock):
+    "Prepare the response to be sent on the socket sock. No work is done to response before send."
+
+    openconn.append(Connection(sock, True, content=response))
+
 def sendResponse(status, contentType, content, sock, headers=[], etag=None):
     "Constructs and sends a response with the first three parameters via sock, optionally with additional headers, and optionally overriding the ETag"
 

--- a/server.py
+++ b/server.py
@@ -381,7 +381,7 @@ def constructResponse(unendedHeaders, content, etag=None):
         response += content
     return response
 
-def queueResponse(response, sock):
+def queueResponse(sock, response):
     "Prepare the response to be sent on the socket sock. No work is done to response before send."
 
     openconn.append(Connection(sock, True, content=response))

--- a/server.py
+++ b/server.py
@@ -823,12 +823,12 @@ while True:
     # And also add the incoming connection accept socket
     r.append(Connection(sock, False, True))
 
-    # Now, select sockets to read from
+    # Now, select sockets to process
     logger.debug("Selection...")
-    readable, u1, u2 = select.select(r, [], [])
+    readable, writeable, u2 = select.select(r, w, [])
     logger.debug("Selected %d readable sockets.", len(readable))
 
-    # And process all those sockets
+    # Read from the readable sockets
     for read in readable:
         # Ignore erroneous sockets (those with negative file descriptors)
         if read.fileno() < 0:

--- a/server.py
+++ b/server.py
@@ -1246,3 +1246,7 @@ while True:
         # Handling writes is a lot easier than reads, because the read logic has made all the decisions.
         logger.info("Sent response to socket %d.", write.fileno())
         write.conn.sendall(write.content)
+
+        # Close the connection and remove it from the waiting list
+        write.conn.close()
+        openconn.remove(write)

--- a/server.py
+++ b/server.py
@@ -718,10 +718,11 @@ def ariaRequest(requestBody, conn):
 
 # Class to store an open connection
 class Connection:
-    def __init__(self, conn, isWrite, isAccept=False, IP=None):
+    def __init__(self, conn, isWrite, isAccept=False, content=None, IP=None):
         self.conn = conn
         self.isWrite=isWrite
         self.isAccept = isAccept
+        self.content = content
         self.IP=IP
 
     # Follows configured behavior to attempt to get an IP out of request headers

--- a/server.py
+++ b/server.py
@@ -840,7 +840,7 @@ while True:
         # For the accept socket, accept the connection and add it to the list
         if read.isAccept:
             logger.info("Accepting a new connection.")
-            openconn.append(read.conn.accept()[0])
+            openconn.append(Connection(read.conn.accept()[0], False))
         else:
             logger.info("Processing request from socket %d.", read.fileno())
             # Fetch the HTTP request waiting on read

--- a/server.py
+++ b/server.py
@@ -408,7 +408,7 @@ def sendResponse(status, contentType, content, sock, headers=[], etag=None):
     else:
         queueResponse(sock, constructResponse(basicHeaders(status, contentType), content, etag))
 
-    logger.info("Sent response to socket %d.", sock.fileno())
+    logger.info("Queued response for socket %d.", sock.fileno())
     logger.debug("Response had %d additional headers: \"%s\".", len(headers), ", ".join(headers))
 
 # Probably won't see much use for this... But need it at least for 400 bad request
@@ -1244,4 +1244,5 @@ while True:
     logger.debug("Selected %d writeable sockets.", len(writeable))
     for write in writeable:
         # Handling writes is a lot easier than reads, because the read logic has made all the decisions.
+        logger.info("Sent response to socket %d.", write.fileno())
         write.conn.sendall(write.content)

--- a/server.py
+++ b/server.py
@@ -562,9 +562,9 @@ def ariaRequest(requestBody, conn):
         sock = conn.conn
     # Otherwise, conn needs to be a socket.
     # That socket stays in sock
-    # conn becomes a Connection covering that socket with the IP set from the peername
+    # conn becomes a read Connection covering that socket with the IP set from the peername
     else:
-        conn = Connection(sock)
+        conn = Connection(sock, False)
         conn.IP = sock.getpeername()[0]
 
     # Log the request
@@ -809,9 +809,9 @@ while True:
     r = []
     # Add all waiting connections
     for conn in openconn:
-        r.append(Connection(conn))
+        r.append(Connection(conn, False))
     # And also the incoming connection accept socket
-    r.append(Connection(sock, True))
+    r.append(Connection(sock, False, True))
 
     # Now, select sockets to read from
     logger.debug("Selection...")

--- a/server.py
+++ b/server.py
@@ -809,14 +809,18 @@ basicHeaders("599 Server Pre-create", "MimeType/precreate.file")
 
 # Infinite loop for connection service
 while True:
-    # List of sockets we're waiting to read from
-    # (we do block on writes... But we don't want to wait on reads.)
+    # List of sockets we're waiting to read from or write to
     logger.debug("Assembling socket list")
     r = []
+    w = []
     # Add all waiting connections
     for conn in openconn:
-        r.append(Connection(conn, False))
-    # And also the incoming connection accept socket
+        # Either append to w or r depending on whether the socket is waiting for write or for read
+        if conn.isWrite:
+            w.append(conn)
+        else:
+            r.append(conn)
+    # And also add the incoming connection accept socket
     r.append(Connection(sock, False, True))
 
     # Now, select sockets to read from

--- a/server.py
+++ b/server.py
@@ -718,8 +718,9 @@ def ariaRequest(requestBody, conn):
 
 # Class to store an open connection
 class Connection:
-    def __init__(self, conn, isAccept=False, IP=None):
+    def __init__(self, conn, isWrite, isAccept=False, IP=None):
         self.conn = conn
+        self.isWrite=isWrite
         self.isAccept = isAccept
         self.IP=IP
 


### PR DESCRIPTION
Writes may still block while the client receives an entire file, but they do not block until the socket is ready to receive something.

This pull request fixes #6 .