### PR TITLE
Accept multiple connections if available

### DIFF
--- a/server.py
+++ b/server.py
@@ -108,6 +108,9 @@ sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 sock.bind(("", port))
 sock.listen(int(config['backlog']))
 
+# Set sock as nonblocking
+sock.setblocking(False)
+
 # Helper functions
 def waitingRequest(s, blocksize=4096):
     "Returns a string containing one complete HTTP request from s, loaded in chunks of blocksize"

--- a/server.py
+++ b/server.py
@@ -832,8 +832,9 @@ while True:
             # Accept as many connections as we can until none are immediately ready for accept
             try:
                 while True:
-                    logger.info("Accepting a new connection.")
-                    openconn.append(Connection(read.conn.accept()[0], False))
+                    conn = read.conn.accept()[0]
+                    openconn.append(Connection(conn, False))
+                    logger.info("Accepting a new connection, attached socket %d.", conn.fileno())
             except socket.timeout:
                 pass
             except BlockingIOError:

--- a/server.py
+++ b/server.py
@@ -836,6 +836,8 @@ while True:
                     openconn.append(Connection(read.conn.accept()[0], False))
             except socket.timeout:
                 pass
+            except BlockingIOError:
+                pass
         else:
             logger.info("Processing request from socket %d.", read.fileno())
             # Fetch the HTTP request waiting on read

--- a/server.py
+++ b/server.py
@@ -829,8 +829,13 @@ while True:
 
         # For the accept socket, accept the connection and add it to the list
         if read.isAccept:
-            logger.info("Accepting a new connection.")
-            openconn.append(Connection(read.conn.accept()[0], False))
+            # Accept as many connections as we can until none are immediately ready for accept
+            try:
+                while True:
+                    logger.info("Accepting a new connection.")
+                    openconn.append(Connection(read.conn.accept()[0], False))
+            except socket.timeout:
+                pass
         else:
             logger.info("Processing request from socket %d.", read.fileno())
             # Fetch the HTTP request waiting on read


### PR DESCRIPTION
Up until now, the server has only accepted one connection, because we were only told that we could have more than zero connections without blocking.

This PR changes the accept socket to throw an exception instead of blocking if there are no waiting connections, thus allowing the server to accept as many connections as are waiting whenever connections are waiting.

This greatly improves the performance of the server with multiple clients, as requests can begin processing several selects earlier, and thus the server can handle more than two simultaneous operations (testing with two devices showed the server handling five simultaneous connections without trouble - All five connections were ready throughout the process, and so all five requests were read, processed, had their writes queued and selected, and had received their responses, all within 12 milliseconds of accepting the first connection, running on my laptop).

I've wanted to implement this for a while, and I'm glad it's finally done.