### PR TITLE
Implement content encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is my intent that once development is complete enough to import into Cadence,
 
 ## Requirements
 
-`cadence-server` runs on python3. I'm not sure what the minimum required version is, but it's being tested and developed on 3.6.
+`cadence-server` runs on python3. I'm not sure what the minimum required version is (it's no earlier than 3.3), but it's being tested and developed on 3.6.
 
 In order to run ARIA searches, `cadence-server` requires the `pg8000` module, which can be installed by running `pip install pg8000`.
 

--- a/default-config.ini
+++ b/default-config.ini
@@ -188,6 +188,13 @@ liquidsoap_port = 1234
 # Probably, the number of cores your machine has is a fair start point for this setting
 max_threads = 4
 
+# These options control content encoding
+# The server itself manages how encoding is done, but when it's done is configurable.
+# First, the server will only compress files above this many bytes in size
+# 1460 bytes is how much data can be sent in one Ethernet frame (one MTU, after TCP/IP overhead)
+# Compressing things smaller than this is basically a waste
+minimum_compress_size = 1460
+
 
 #########################################################################################
 # Beyond this line is database configuration                                            #

--- a/default-config.ini
+++ b/default-config.ini
@@ -194,6 +194,8 @@ max_threads = 4
 # 1460 bytes is how much data can be sent in one Ethernet frame (one MTU, after TCP/IP overhead)
 # Compressing things smaller than this is basically a waste
 minimum_compress_size = 1460
+# Only files with a MIME type that matches this regex will be compressed
+compress_type_regex = (text/.*|application/json|application/javascript|application/xml|application/.+\+xml|application/x-font-.+|image/svg\+xml|image/x-icon|image/vnd.microsoft.icon|font/.*)
 
 
 #########################################################################################

--- a/server.py
+++ b/server.py
@@ -385,13 +385,13 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             response += b"ETag: \""+etag+b"\"\r\n"
 
     # Process our encodings
-    if allowEncodings!=None:
+    l=len(content)
+    if allowEncodings!=None and l>int(config['minimum_compress_size']):
         for encoding in allowEncodings:
             if encoding=="identity" or encoding=="*":
                 # We can silently use this encoding
                 break
             elif encoding=="gzip":
-                l=len(content)
                 # Compress the content with gzip
                 content=gzip.compress(content)
                 logger.debug("Compressed content from %d bytes to %d bytes using gzip.", l, len(content))
@@ -400,7 +400,6 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
                 response += b"Content-Encoding: gzip\r\n"
                 break
             elif encoding=="bzip2":
-                l=len(content)
                 # Compress the content with bzip2
                 content=bz2.compress(content)
                 logger.debug("Compressed content from %d bytes to %d bytes using bzip2.", l, len(content))

--- a/server.py
+++ b/server.py
@@ -382,6 +382,11 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
         elif encoding=="gzip":
             # Compress the content with gzip
             content=gzip.compress(content)
+
+            # ETags are content-encoding-dependent.
+            # The passed tag is an identity tag.
+            # Add a note to identify it as a gzip tag
+            etag+="-gzip"
             break
 
     # Add ETag iff we have caching set

--- a/server.py
+++ b/server.py
@@ -407,9 +407,9 @@ def sendResponse(status, contentType, content, sock, headers=[], allowEncodings=
     # If additional headers are specified, format them for HTTP
     # Else, send as normal
     if len(headers)>0:
-        queueResponse(sock, constructResponse(basicHeaders(status, contentType)+("\r\n".join(headers)+"\r\n").encode(), content, etag))
+        queueResponse(sock, constructResponse(basicHeaders(status, contentType)+("\r\n".join(headers)+"\r\n").encode(), content, allowEncodings, etag))
     else:
-        queueResponse(sock, constructResponse(basicHeaders(status, contentType), content, etag))
+        queueResponse(sock, constructResponse(basicHeaders(status, contentType), content, allowEncodings, etag))
 
     logger.info("Queued response for socket %d.", sock.fileno())
     logger.debug("Response had %d additional headers: \"%s\".", len(headers), ", ".join(headers))

--- a/server.py
+++ b/server.py
@@ -390,6 +390,15 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             # Add a note to identify it as a gzip tag
             etag+="-gzip"
             break
+        elif encoding=="bzip2":
+            # Compress the content with bzip2
+            content=bz2.compress(content)
+
+            # ETags are content-encoding-dependent.
+            # The passed tag is an identity tag.
+            # Add a note to identify it as a bzip2 tag
+            etag+="-bzip2"
+            break
 
     # Add ETag iff we have caching set
     if caching>0:

--- a/server.py
+++ b/server.py
@@ -370,6 +370,20 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
 
     response =  unendedHeaders
 
+    # Accept a str content
+    if isinstance(content, str):
+        content = content.encode()
+
+    # Process our encodings
+    for encoding in encodings:
+        if encoding=="identity" or encoding=="*":
+            # We can silently use this encoding
+            break
+        elif encoding=="gzip":
+            # Compress the content with gzip
+            content=gzip.compress(content)
+            break
+
     # Add ETag iff we have caching set
     if caching>0:
         # Either generate our own, or use the provided one
@@ -379,10 +393,7 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             response += b"ETag: \""+etag+b"\"\r\n"
 
     response += b"Content-Length: "+str(len(content)).encode()+b"\r\n\r\n"
-    if isinstance(content, str):
-        response += content.encode()
-    else:
-        response += content
+    response += content
     return response
 
 def queueResponse(sock, response):

--- a/server.py
+++ b/server.py
@@ -392,6 +392,9 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             # Add a note to identify it as a gzip tag
             if etag!=None:
                 etag+="-gzip"
+
+            # Add an encoding header
+            response += b"Content-Encoding: gzip\r\n"
             break
         elif encoding=="bzip2":
             l=len(content)
@@ -404,6 +407,9 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             # Add a note to identify it as a bzip2 tag
             if etag!=None:
                 etag+="-bzip2"
+
+            # Add an encoding header
+            response += b"Content-Encoding: bzip2\r\n"
             break
 
     # Add ETag iff we have caching set

--- a/server.py
+++ b/server.py
@@ -371,6 +371,10 @@ def basicHeaders(status, contentType):
 def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
     "Attaches unendedHeaders and content into one HTTP response (adding content-length in the process), optionally overriding the etag. allowEncodings should be a list of strings of allowed encodings, or None."
 
+    # Pre-compile our regex pattern
+    if not hasattr(constructResponse, "compressPattern"):
+        constructResponse.compressPattern=re.compile(config['compress_type_regex'], re.IGNORECASE)
+
     response =  unendedHeaders
 
     # Accept a str content

--- a/server.py
+++ b/server.py
@@ -382,8 +382,10 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             # We can silently use this encoding
             break
         elif encoding=="gzip":
+            l=len(content)
             # Compress the content with gzip
             content=gzip.compress(content)
+            logger.debug("Compressed content from %d bytes to %d bytes using gzip.", l, len(content))
 
             # ETags are content-encoding-dependent.
             # The passed tag is an identity tag.
@@ -392,8 +394,10 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
                 etag+="-gzip"
             break
         elif encoding=="bzip2":
+            l=len(content)
             # Compress the content with bzip2
             content=bz2.compress(content)
+            logger.debug("Compressed content from %d bytes to %d bytes using bzip2.", l, len(content))
 
             # ETags are content-encoding-dependent.
             # The passed tag is an identity tag.

--- a/server.py
+++ b/server.py
@@ -13,6 +13,7 @@ import traceback
 import pg8000
 import string
 import gzip
+import bz2
 import logging
 import logging.handlers
 from telnetlib import Telnet

--- a/server.py
+++ b/server.py
@@ -377,7 +377,7 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
         content = content.encode()
 
     # Process our encodings
-    for encoding in encodings:
+    for encoding in allowEncodings:
         if encoding=="identity" or encoding=="*":
             # We can silently use this encoding
             break

--- a/server.py
+++ b/server.py
@@ -417,6 +417,14 @@ def constructResponse(unendedHeaders, content, contentType, allowEncodings=None,
                 # Add an encoding header
                 response += b"Content-Encoding: bzip2\r\n"
                 break
+            elif encoding=="xz":
+                # Compress the content with LZMA2 (as an XZ container)
+                content=lzma.compress(content, lzma.FORMAT_XZ)
+                logger.debug("Compressed content from %d bytes to %d bytes using LZMA2.", l, len(content))
+
+                # Add an encoding header
+                response += b"Content-Encoding: xz\r\n"
+                break
 
     response += b"Content-Length: "+str(len(content)).encode()+b"\r\n\r\n"
     response += content

--- a/server.py
+++ b/server.py
@@ -385,28 +385,29 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             response += b"ETag: \""+etag+b"\"\r\n"
 
     # Process our encodings
-    for encoding in allowEncodings:
-        if encoding=="identity" or encoding=="*":
-            # We can silently use this encoding
-            break
-        elif encoding=="gzip":
-            l=len(content)
-            # Compress the content with gzip
-            content=gzip.compress(content)
-            logger.debug("Compressed content from %d bytes to %d bytes using gzip.", l, len(content))
+    if allowEncodings!=None:
+        for encoding in allowEncodings:
+            if encoding=="identity" or encoding=="*":
+                # We can silently use this encoding
+                break
+            elif encoding=="gzip":
+                l=len(content)
+                # Compress the content with gzip
+                content=gzip.compress(content)
+                logger.debug("Compressed content from %d bytes to %d bytes using gzip.", l, len(content))
 
-            # Add an encoding header
-            response += b"Content-Encoding: gzip\r\n"
-            break
-        elif encoding=="bzip2":
-            l=len(content)
-            # Compress the content with bzip2
-            content=bz2.compress(content)
-            logger.debug("Compressed content from %d bytes to %d bytes using bzip2.", l, len(content))
+                # Add an encoding header
+                response += b"Content-Encoding: gzip\r\n"
+                break
+            elif encoding=="bzip2":
+                l=len(content)
+                # Compress the content with bzip2
+                content=bz2.compress(content)
+                logger.debug("Compressed content from %d bytes to %d bytes using bzip2.", l, len(content))
 
-            # Add an encoding header
-            response += b"Content-Encoding: bzip2\r\n"
-            break
+                # Add an encoding header
+                response += b"Content-Encoding: bzip2\r\n"
+                break
 
     response += b"Content-Length: "+str(len(content)).encode()+b"\r\n\r\n"
     response += content

--- a/server.py
+++ b/server.py
@@ -347,6 +347,7 @@ def basicHeaders(status, contentType):
         basicHeaders.format =  "HTTP/1.1 {0}\r\n"
         basicHeaders.format += "Date: {1}\r\n"
         basicHeaders.format += "Connection: close\r\n"
+        basicHeaders.format += "Vary: Accept-Encoding\r\n"
 
         # Advertise the configured state of our range request support
         if config.getboolean("enable_range_requests"):

--- a/server.py
+++ b/server.py
@@ -388,7 +388,8 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             # ETags are content-encoding-dependent.
             # The passed tag is an identity tag.
             # Add a note to identify it as a gzip tag
-            etag+="-gzip"
+            if etag!=None:
+                etag+="-gzip"
             break
         elif encoding=="bzip2":
             # Compress the content with bzip2
@@ -397,7 +398,8 @@ def constructResponse(unendedHeaders, content, allowEncodings=None, etag=None):
             # ETags are content-encoding-dependent.
             # The passed tag is an identity tag.
             # Add a note to identify it as a bzip2 tag
-            etag+="-bzip2"
+            if etag!=None:
+                etag+="-bzip2"
             break
 
     # Add ETag iff we have caching set

--- a/server.py
+++ b/server.py
@@ -14,6 +14,7 @@ import pg8000
 import string
 import gzip
 import bz2
+import re
 import logging
 import logging.handlers
 from telnetlib import Telnet

--- a/server.py
+++ b/server.py
@@ -15,6 +15,7 @@ import string
 import gzip
 import bz2
 import re
+import lzma
 import logging
 import logging.handlers
 from telnetlib import Telnet

--- a/server.py
+++ b/server.py
@@ -391,7 +391,11 @@ def constructResponse(unendedHeaders, content, contentType, allowEncodings=None,
 
     # Process our encodings
     l=len(content)
-    if allowEncodings!=None and l>int(config['minimum_compress_size']):
+    # Only attempt to find an encoding if:
+    #   - We have some allowed encodings object to process
+    #   - The size of our content is large enough that we're configured to compress it
+    #   - The MIME type of our file is configured to be compressed.
+    if allowEncodings!=None and l>int(config['minimum_compress_size']) and constructResponse.compressPattern.fullmatch(contentType)!=None:
         for encoding in allowEncodings:
             if encoding=="identity" or encoding=="*":
                 # We can silently use this encoding

--- a/server.py
+++ b/server.py
@@ -12,6 +12,7 @@ import math
 import traceback
 import pg8000
 import string
+import gzip
 import logging
 import logging.handlers
 from telnetlib import Telnet


### PR DESCRIPTION
The server, when permitted to do so by the browser and by its configuration, may use any of these algorithms to compress files:

- `gzip`

- `bzip2`

- `lzma2`

This can reduce bandwidth by very large amounts, depending on the file in question, but increases memory usage and consumes processor time.

It is also only useful for files which are not already compressed by another algorithm - the configuration is extended with an option to choose which types of file are considered compressible (by regex on mimetype).

Finally, small enough files aren't really worth compressing. If we don't save MTUs, then we didn't save much in the process of shrinking the file. Therefore, another config option controls the minimum size of a file considered for compression - The default is set to one Ethernet MTU, minus the overhead of the TCP and IP protocols. This is a bit larger than what might show improvement, as it disregards the overhead from HTTP headers, but it's a decent guess.

This PR fixes #10 and #11.